### PR TITLE
python-flask-docker to 0.0.3

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -9,4 +9,4 @@ dependencies:
   version: 2.3.82
 - name: python-flask-docker
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.2
+  version: 0.0.3


### PR DESCRIPTION
Promote python-flask-docker to version 0.0.3